### PR TITLE
🍻 Package whould not be private

### DIFF
--- a/templates/package.templ
+++ b/templates/package.templ
@@ -4,7 +4,6 @@
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "private": true,
   "scripts": {
     "lint": "eslint --ext .ts",
     "test": "jest",


### PR DESCRIPTION
The `private` flag in package.json means that the package cannot be published at all. I don't think we should have this